### PR TITLE
PIZ1: Fix can't create an order

### DIFF
--- a/app/services/size.py
+++ b/app/services/size.py
@@ -6,6 +6,14 @@ from ..controllers import SizeController
 size = Blueprint('size', __name__)
 
 
+@size.route('/', methods=GET)
+def get_all():
+    size, error = SizeController.get_all()
+    response = size if not error else {'error': error}
+    status_code = 200 if not error else 400
+    return jsonify(response), status_code
+
+
 @size.route('/', methods=POST)
 def create_size():
     size, error = SizeController.create(request.json)


### PR DESCRIPTION
## Description 🔍

- Adding a **_size_** service: Root ('/') endpoint with GET method that run the 'get_all' function of the Size controller

## Trello ticket link ✅

https://trello.com/c/b3qJVV2Q/1-piz1-i-cant-create-an-order-bug

## Type of change 🤔

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test results 🔬

![image](https://user-images.githubusercontent.com/106180152/191162360-8279523d-426e-4dc4-8a73-f6c269ba2a46.png)